### PR TITLE
fix(bot): Global commands cannot access guild id

### DIFF
--- a/discord-bot/src/interactions/application_commands/admin/mm_settings_handler.rs
+++ b/discord-bot/src/interactions/application_commands/admin/mm_settings_handler.rs
@@ -40,13 +40,6 @@ impl InteractionHandler for MatchmakingSettingsHandler {
     async fn process_command(&self, data: Box<ApplicationCommandData>) -> anyhow::Result<()> {
         let command = &data.command;
         // VERIFY: Is it possible that we can send the information of other guilds here?
-        let _guild_id = match command.guild_id {
-            Some(id) => id,
-            None => {
-                return Err(anyhow!("Can't find a guild id for this command."));
-            }
-        };
-
         debug!(data = ?format!("{:?}", data.command));
 
         let group = data
@@ -90,14 +83,7 @@ impl InteractionHandler for MatchmakingSettingsHandler {
         match subcommand.name.as_str() {
             "matchmaking-channel" => {
                 // Creates the guild settings object if it doens't exist
-                let settings = self
-                    .utils
-                    .get_guild_settings(
-                        data.command
-                            .guild_id
-                            .ok_or_else(|| anyhow!("this command cannot be used in a DM"))?,
-                    )
-                    .await?;
+                let settings = self.utils.get_guild_settings(data.guild_id).await?;
 
                 let mut model = matchmaking_settings::ActiveModel {
                     guild_id: Set(settings.guild_id),
@@ -146,10 +132,7 @@ impl InteractionHandler for MatchmakingSettingsHandler {
             }
             "admin-role" => {
                 // Creates the guild settings object if it doens't exist
-                let settings = self
-                    .utils
-                    .get_guild_settings(data.command.guild_id.unwrap())
-                    .await?;
+                let settings = self.utils.get_guild_settings(data.guild_id).await?;
 
                 let mut model = matchmaking_settings::ActiveModel {
                     guild_id: Set(settings.guild_id),

--- a/discord-bot/src/interactions/application_commands/mod.rs
+++ b/discord-bot/src/interactions/application_commands/mod.rs
@@ -22,6 +22,7 @@ use twilight_model::{
     },
     channel::message::MessageFlags,
     http::interaction::{InteractionResponse, InteractionResponseType},
+    id::marker::GuildMarker,
 };
 use twilight_util::builder::command::{CommandBuilder, StringBuilder};
 use twilight_util::builder::embed::{EmbedBuilder, EmbedFieldBuilder};
@@ -53,7 +54,7 @@ pub struct ApplicationCommandData {
     pub interaction: Interaction,
     pub command: CommandData,
     pub id: Uuid,
-    // pub cancellation_token
+    pub guild_id: Id<GuildMarker>, // pub cancellation_token
 }
 
 #[derive(Debug)]

--- a/discord-bot/src/interactions/mod.rs
+++ b/discord-bot/src/interactions/mod.rs
@@ -214,6 +214,9 @@ impl InteractionProcessor {
                         command: *command.clone(),
                         id: Uuid::new_v4(),
                         interaction: interaction.0.clone(),
+                        guild_id: interaction
+                            .guild_id
+                            .ok_or_else(|| anyhow!("you must run this command in a valid guild"))?,
                     });
                     let fut = Box::pin(Self::execute_application_command(
                         handler.clone(),


### PR DESCRIPTION
Fixes error `Can't find a guild id for this command.`. This is due to `data.command.guild_id` returning the id of the guild that the command is registered in rather than the current guild that the command was run in.